### PR TITLE
chore: upgrade pnpm to 11.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"engines": {
 		"node": ">=24"
 	},
-	"packageManager": "pnpm@10.33.0",
+	"packageManager": "pnpm@11.8.0",
 	"scripts": {
 		"--- MAIN SCRIPTS ---": "------------------------------------------------------------",
 		"start": "pnpm run dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,13 @@ packages:
   - .
 overrides:
   'yaml': '^2.8.3'
+# pnpm 11 requires an explicit decision on which dependencies may run
+# install/build scripts. None are needed for our build: these packages ship
+# prebuilt binaries, and under pnpm 10 they were all ignored while the build
+# still passed. Keep them disabled to preserve that behavior.
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  netlify-cli: false
+  sharp: false
+  unix-dgram: false


### PR DESCRIPTION
## Summary

Upgrades the pinned package manager from pnpm 10.33.0 to **11.8.0**. Kept separate from the CI-hardening work (#384, now merged) because pnpm 11 is a build-tool major with a behavior change that warrants its own review.

## What changed

- `package.json` — `packageManager: pnpm@11.8.0`
- `pnpm-workspace.yaml` — pnpm 11 turns *ignored build scripts* into a **hard error** and requires an explicit `allowBuilds` decision per package. All five (`@parcel/watcher`, `esbuild`, `netlify-cli`, `sharp`, `unix-dgram`) are set to `false`: they ship prebuilt binaries and were already ignored under pnpm 10 while the build passed, so this preserves existing behavior.

The lockfile is **unchanged** — pnpm 11 reads the existing one as-is.

## Notes

- Enabling the native build scripts (`true`) caused the install to hang in a non-TTY environment, and they aren't needed for the build, so disabling is both safer and behavior-preserving. Any package can be flipped to `true` later if a real native build is required.
- CI picks up pnpm 11 automatically via `pnpm/action-setup` reading the `packageManager` field.

## Verification

Fresh `pnpm install --frozen-lockfile` plus `format:check` / `check` / `lint` / `build` all pass under pnpm 11.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)