### PR TITLE
feat: add photo lightbox (astro-pandabox) with shareable deep links

### DIFF
--- a/src/components/Pandabox.astro
+++ b/src/components/Pandabox.astro
@@ -1,0 +1,531 @@
+---
+// Lightbox component adapted from astro-pandabox by SaintSin (MIT):
+// https://github.com/SaintSin/astro-pandabox
+// Adapted to this site's gallery schema ({ img, caption }) and to run without
+// the View Transitions router (init on DOM ready instead of astro:page-load).
+import { Image } from 'astro:assets';
+import { type CollectionEntry, getEntry } from 'astro:content';
+
+interface Props {
+	galleryid?: string;
+	gallery?: CollectionEntry<'galleries'>;
+	transitionType?: 'fade' | 'slide';
+}
+
+const { galleryid, gallery: galleryProp, transitionType = 'fade' } = Astro.props;
+
+const gallery = galleryProp ?? (galleryid ? await getEntry('galleries', galleryid) : undefined);
+const id = gallery?.id ?? galleryid ?? 'gallery';
+
+// Map the site's { img, caption } gallery schema onto Pandabox's fields.
+const images = (gallery?.data.images ?? []).map((image) => ({
+	src: image.img,
+	alt: image.caption,
+	title: image.caption,
+	description: '',
+}));
+---
+
+<section class="thumbnail-container gallery" id={'gallery-' + id}>
+	{
+		images.map((image, index) => (
+			<button class="thumbnail-button" data-index={index} aria-label={`View image ${index + 1}: ${image.alt}`}>
+				<Image
+					src={image.src}
+					alt={image.alt}
+					layout="constrained"
+					width={300}
+					quality={40}
+					loading="eager"
+					data-index={index}
+					class="thumbnail"
+				/>
+			</button>
+		))
+	}
+	<dialog class="lightbox-dialog" data-option={transitionType}>
+		<div class="lightbox-content">
+			{
+				images.map((image, index) => (
+					<figure class="lightbox-image-container" id={`image-${index}`}>
+						<div class="lightbox-image-wrapper">
+							<Image
+								src={image.src}
+								alt={image.alt}
+								layout="full-width"
+								quality={40}
+								loading={index < 4 ? 'eager' : 'lazy'}
+								class="lightbox-image"
+								data-index={index}
+							/>
+						</div>
+						<figcaption class="lightbox-caption">
+							{image.title ? (
+								<p>
+									{index + 1}. {image.title}
+								</p>
+							) : null}
+							{image.description ? <p>{image.description}</p> : null}
+						</figcaption>
+					</figure>
+				))
+			}
+		</div>
+		<button class="prev-button" aria-label="previous slide">
+			<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+				<path
+					fill="currentColor"
+					d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2m8 15H11.85l5.58 5.573L16 24l-8-8l8-8l1.43 1.393L11.85 15H24Z"
+				></path>
+			</svg>
+		</button>
+		<button class="next-button" aria-label="next slide">
+			<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+				<path
+					fill="currentColor"
+					d="M2 16A14 14 0 1 0 16 2A14 14 0 0 0 2 16m6-1h12.15l-5.58-5.607L16 8l8 8l-8 8l-1.43-1.427L20.15 17H8Z"
+				></path>
+			</svg>
+		</button>
+		<button class="close-button" aria-label="close button">
+			<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+				<path
+					fill="currentColor"
+					d="M16 2C8.2 2 2 8.2 2 16s6.2 14 14 14s14-6.2 14-14S23.8 2 16 2m5.4 21L16 17.6L10.6 23L9 21.4l5.4-5.4L9 10.6L10.6 9l5.4 5.4L21.4 9l1.6 1.6l-5.4 5.4l5.4 5.4z"
+				></path>
+			</svg>
+		</button>
+	</dialog>
+</section>
+
+<style>
+	.lightbox-dialog {
+		--duration-zoom-in: 0.75s;
+		--duration-background-transition: 0.3s;
+		--duration-slide-transition: 0.3s;
+		--duration-close-transition: 0.5s;
+		--caption-height: 5lh;
+		--ease-zoom: cubic-bezier(0.5, -0.5, 0.1, 1.5);
+		--ease-slide-transition: cubic-bezier(0.9, 0, 0.1, 1);
+	}
+	@media (prefers-reduced-motion) {
+		.lightbox-dialog {
+			--duration-zoom-in: 0s;
+			--duration-slide-transition: 0s;
+			--duration-background-transition: 0s;
+			--duration-close-transition: 0s;
+		}
+	}
+
+	.thumbnail-container img,
+	.lightbox-dialog img,
+	.lightbox-dialog picture {
+		display: block;
+		width: 100%;
+		height: auto;
+		object-fit: cover;
+	}
+
+	:global(html:has(dialog.lightbox-dialog[open])) {
+		overflow: hidden;
+	}
+
+	.thumbnail-container {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+		gap: clamp(1rem, 2vw, 1.5rem);
+		overflow: clip;
+	}
+	.thumbnail-button {
+		cursor: zoom-in;
+		padding: 0;
+		border: none;
+		border-radius: 1.5rem;
+		background: none;
+		overflow: clip;
+		outline: none;
+	}
+	.thumbnail-button:focus {
+		outline: none;
+	}
+
+	.lightbox-dialog {
+		display: none;
+		transform: translateX(100%);
+		opacity: 0;
+		transition:
+			overlay 1s ease-in allow-discrete,
+			display 1s ease-in allow-discrete;
+		border: none;
+		background: none;
+		padding: 0;
+		overflow: clip;
+	}
+	@media (width <= 640px) {
+		.lightbox-dialog {
+			transition:
+				overlay 0s ease-in allow-discrete,
+				display 0s ease-in allow-discrete;
+		}
+	}
+	.lightbox-dialog[open] {
+		display: grid;
+		grid-template-rows: [main-start] 5ch [interior-start] 1fr [interior-end] 5ch [main-end];
+		grid-template-columns: [main-start] 10ch [interior-start] 1fr [interior-end] 10ch [main-end];
+		grid-template-areas:
+			'tlhs top trhs'
+			'clhs content crhs'
+			'blhs bottom brhs';
+		transform: translateX(0);
+		opacity: 1;
+		max-width: 100%;
+		height: 100dvh;
+		max-height: 100%;
+	}
+
+	@starting-style {
+		.lightbox-dialog[open] {
+			translate: 0 100vh;
+		}
+		.lightbox-dialog[open]::backdrop {
+			opacity: 0;
+		}
+		.lightbox-dialog[open] .lightbox-content .lightbox-image-container .lightbox-caption {
+			opacity: 0;
+		}
+		.lightbox-dialog[open] button {
+			opacity: 0;
+		}
+	}
+	.lightbox-dialog[open]::backdrop {
+		opacity: 1;
+	}
+	.lightbox-dialog::backdrop {
+		opacity: 0;
+		background: oklch(40% 0 0 / 95%);
+	}
+	@starting-style {
+		.lightbox-dialog[open]::backdrop {
+			opacity: 0;
+		}
+	}
+	.lightbox-dialog.closing::backdrop {
+		opacity: 0;
+		transition: opacity var(--duration-close-transition) ease;
+	}
+	.lightbox-dialog.closing {
+		opacity: 0;
+		transition: opacity var(--duration-close-transition) ease;
+	}
+
+	.lightbox-content {
+		display: grid;
+		grid-template-rows: 1fr;
+		grid-template-columns: 1fr;
+		grid-template-areas: 'content';
+		grid-row-start: main-start;
+		grid-row-end: main-end;
+		grid-column-start: main-start;
+		grid-column-end: main-end;
+		width: 100dvw;
+		height: 100dvh;
+	}
+
+	.lightbox-image-container {
+		display: grid;
+		grid-template-rows: 1fr var(--caption-height);
+		grid-template-columns: 1fr;
+		grid-template-areas:
+			'image'
+			'caption';
+		grid-area: content;
+		place-content: center;
+		opacity: 0;
+		transition:
+			opacity var(--duration-slide-transition) var(--ease-slide-transition),
+			transform var(--duration-slide-transition) var(--ease-slide-transition);
+		pointer-events: none;
+	}
+	.lightbox-image-container.active {
+		opacity: 1;
+		pointer-events: auto;
+	}
+	.lightbox-image-wrapper {
+		grid-area: image;
+	}
+	.lightbox-caption {
+		grid-area: caption;
+		opacity: 1;
+		transition: opacity var(--duration-background-transition) ease-in;
+		padding: 1ch;
+	}
+	.lightbox-image {
+		--initial-scale: 1;
+		--initial-x: 0px;
+		--initial-y: 0px;
+		--final-x: 0px;
+		--final-y: 0px;
+		--final-scale: 1;
+		transform-origin: top left;
+		opacity: 1;
+		animation: zoom-in-animation var(--duration-zoom-in) var(--ease-zoom) forwards;
+		width: auto;
+		max-height: calc(100dvh - var(--caption-height));
+	}
+	@keyframes zoom-in-animation {
+		from {
+			transform: translate(var(--initial-x), var(--initial-y)) scale(var(--initial-scale));
+		}
+		to {
+			transform: translate(var(--final-x), var(--final-y)) scale(var(--final-scale));
+		}
+	}
+
+	.lightbox-dialog[data-option='fade'] .lightbox-image-container {
+		transform: none;
+	}
+	.lightbox-dialog[data-option='slide'] .lightbox-image-container {
+		transform: translateX(100%);
+	}
+	.lightbox-dialog[data-option='slide'] .lightbox-image-container.previous {
+		transform: translateX(-100%);
+	}
+	.lightbox-dialog[data-option='slide'] .lightbox-image-container.next {
+		transform: translateX(100%);
+	}
+	.lightbox-dialog[data-option='slide'] .lightbox-image-container.active {
+		transform: translateX(0%);
+	}
+
+	.lightbox-caption p {
+		margin: auto;
+		color: oklch(95% 0 0);
+		font-weight: 200;
+		text-align: center;
+		text-wrap: pretty;
+	}
+	.lightbox-caption p:first-child {
+		padding-block-start: 1.5rem;
+		padding-block-end: 0.75rem;
+		font-weight: 800;
+	}
+
+	.lightbox-dialog button {
+		opacity: 1;
+		z-index: 999;
+		transition: opacity var(--duration-background-transition) ease-in allow-discrete;
+		outline: none;
+		border: none;
+	}
+	.lightbox-dialog button svg {
+		transition: all 0.2s ease-in-out;
+		padding: 0;
+		aspect-ratio: 1 / 1;
+		width: 38px;
+		height: 100%;
+		color: oklch(60% 0.01 150 / 75%);
+	}
+	.lightbox-dialog button:hover svg {
+		color: oklch(85% 0.15 150 / 95%);
+	}
+	.prev-button,
+	.next-button,
+	.close-button {
+		display: block;
+		cursor: pointer;
+		background: none;
+	}
+	.prev-button {
+		grid-area: clhs;
+		padding-right: 50%;
+	}
+	.next-button {
+		grid-area: crhs;
+		padding-left: 50%;
+	}
+	.close-button {
+		grid-area: trhs;
+		cursor: zoom-out;
+		padding-left: 50%;
+	}
+</style>
+
+<script>
+	function setupLightbox(): void {
+		const thumbnailButtons = document.querySelectorAll<HTMLButtonElement>('.thumbnail-button img');
+		const lightboxDialog = document.querySelector<HTMLDialogElement>('.lightbox-dialog');
+		const prevButton = document.querySelector<HTMLButtonElement>('.prev-button');
+		const nextButton = document.querySelector<HTMLButtonElement>('.next-button');
+		const closeButton = document.querySelector<HTMLButtonElement>('.close-button');
+
+		if (!lightboxDialog || thumbnailButtons.length === 0) return;
+
+		const closeDuration =
+			parseFloat(getComputedStyle(lightboxDialog).getPropertyValue('--duration-close-transition')) * 1000;
+
+		let currentIndex = 0;
+		let resizeTimeout: number | undefined;
+
+		function calculateCentering(image: HTMLImageElement): void {
+			const wrapper = image.closest('.lightbox-image-wrapper') as HTMLElement | null;
+			if (!wrapper) return;
+
+			const wrapperRect = wrapper.getBoundingClientRect();
+			const wrapperWidth = wrapperRect.width;
+			const wrapperHeight = wrapperRect.height;
+			if (!wrapperWidth || !wrapperHeight) return;
+
+			const imageWidth = Number.parseFloat(image.getAttribute('width') || '0');
+			const imageHeight = Number.parseFloat(image.getAttribute('height') || '0');
+			if (!imageWidth || !imageHeight) return;
+
+			const imageAspectRatio = imageWidth / imageHeight;
+			const wrapperAspectRatio = wrapperWidth / wrapperHeight;
+
+			let finalX = 0;
+			let finalY = 0;
+			if (wrapperAspectRatio > imageAspectRatio) {
+				const targetWidth = wrapperHeight * imageAspectRatio;
+				finalX = (wrapperWidth - targetWidth) / 2;
+			} else {
+				const targetHeight = wrapperWidth / imageAspectRatio;
+				finalY = (wrapperHeight - targetHeight) / 2;
+			}
+
+			finalX = Math.max(0, finalX);
+			finalY = Math.max(0, finalY);
+
+			image.style.setProperty('--final-x', `${finalX}px`);
+			image.style.setProperty('--final-y', `${finalY}px`);
+			image.style.setProperty('--final-scale', '1');
+		}
+
+		function showImageAtIndex(index: number): void {
+			const containers = document.querySelectorAll<HTMLElement>('.lightbox-image-container');
+			if (index < 0 || index >= containers.length) return;
+
+			for (const container of containers) {
+				container.classList.remove('active', 'previous', 'next');
+			}
+
+			const newActive = document.getElementById(`image-${index}`);
+			if (!newActive) return;
+
+			newActive.classList.add('active');
+			currentIndex = index;
+
+			const image = newActive.querySelector<HTMLImageElement>('.lightbox-image');
+			if (image) calculateCentering(image);
+
+			const prevIndex = (currentIndex - 1 + containers.length) % containers.length;
+			const nextIndex = (currentIndex + 1) % containers.length;
+			document.getElementById(`image-${prevIndex}`)?.classList.add('previous');
+			document.getElementById(`image-${nextIndex}`)?.classList.add('next');
+		}
+
+		function openLightbox(button: HTMLElement): void {
+			if (!lightboxDialog) return;
+
+			const rect = button.getBoundingClientRect();
+			const index = Number.parseInt(button.dataset.index || '0', 10);
+			const activeImage = document.getElementById(`image-${index}`);
+			if (!activeImage) return;
+
+			activeImage.classList.add('active');
+			lightboxDialog.showModal();
+			currentIndex = index;
+
+			requestAnimationFrame(() => {
+				const wrapper = activeImage.querySelector<HTMLDivElement>('.lightbox-image-wrapper');
+				if (!wrapper) return;
+
+				const wrapperRect = wrapper.getBoundingClientRect();
+				if (wrapperRect.width === 0 || wrapperRect.height === 0) return;
+
+				const lightboxImage = activeImage.querySelector<HTMLImageElement>('.lightbox-image');
+				if (!lightboxImage) return;
+
+				const buttonAspectRatio = rect.width / rect.height;
+				const wrapperAspectRatio = wrapperRect.width / wrapperRect.height;
+				const initialScale =
+					buttonAspectRatio > wrapperAspectRatio ? rect.width / wrapperRect.width : rect.height / wrapperRect.height;
+
+				lightboxImage.style.setProperty('--initial-x', `${rect.left}px`);
+				lightboxImage.style.setProperty('--initial-y', `${rect.top}px`);
+				lightboxImage.style.setProperty('--initial-scale', `${initialScale}`);
+
+				if (lightboxDialog.getAttribute('data-option') !== 'slide') {
+					calculateCentering(lightboxImage);
+				}
+				showImageAtIndex(currentIndex);
+			});
+		}
+
+		function showPreviousImage(): void {
+			showImageAtIndex((currentIndex - 1 + thumbnailButtons.length) % thumbnailButtons.length);
+		}
+
+		function showNextImage(): void {
+			showImageAtIndex((currentIndex + 1) % thumbnailButtons.length);
+		}
+
+		function closeDialog(): void {
+			if (!lightboxDialog) return;
+			lightboxDialog.classList.add('closing');
+			setTimeout(() => {
+				lightboxDialog.close();
+				lightboxDialog.classList.remove('closing');
+			}, closeDuration);
+		}
+
+		function handleKeydown(event: KeyboardEvent): void {
+			if (!lightboxDialog || !lightboxDialog.open) return;
+			if (event.key === 'ArrowLeft') showPreviousImage();
+			else if (event.key === 'ArrowRight') showNextImage();
+			else if (event.key === 'Escape') {
+				event.preventDefault();
+				closeDialog();
+			}
+		}
+
+		function handleSwipe(event: TouchEvent): void {
+			const touchStartX = event.touches[0].clientX;
+			function handleTouchEnd(touchEndEvent: TouchEvent): void {
+				const deltaX = touchEndEvent.changedTouches[0].clientX - touchStartX;
+				if (deltaX > 50) showPreviousImage();
+				else if (deltaX < -50) showNextImage();
+				document.removeEventListener('touchend', handleTouchEnd);
+			}
+			document.addEventListener('touchend', handleTouchEnd);
+		}
+
+		for (const button of thumbnailButtons) {
+			button.addEventListener('click', () => openLightbox(button));
+		}
+		prevButton?.addEventListener('click', showPreviousImage);
+		nextButton?.addEventListener('click', showNextImage);
+		closeButton?.addEventListener('click', closeDialog);
+		document.addEventListener('keydown', handleKeydown);
+		document.addEventListener('touchstart', handleSwipe);
+
+		window.addEventListener('resize', () => {
+			clearTimeout(resizeTimeout);
+			resizeTimeout = window.setTimeout(() => {
+				document.querySelectorAll<HTMLImageElement>('.lightbox-image').forEach(calculateCentering);
+			}, 300);
+		});
+
+		lightboxDialog.addEventListener('close', () => {
+			for (const container of document.querySelectorAll<HTMLElement>('.lightbox-image-container')) {
+				container.classList.remove('active', 'previous', 'next');
+			}
+		});
+	}
+
+	// This site does not use the View Transitions router, so init on DOM ready.
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', setupLightbox);
+	} else {
+		setupLightbox();
+	}
+</script>

--- a/src/components/Pandabox.astro
+++ b/src/components/Pandabox.astro
@@ -17,12 +17,22 @@ const { galleryid, gallery: galleryProp, transitionType = 'fade' } = Astro.props
 const gallery = galleryProp ?? (galleryid ? await getEntry('galleries', galleryid) : undefined);
 const id = gallery?.id ?? galleryid ?? 'gallery';
 
+// Derive a stable, reorder-proof identifier from the source filename. The
+// emitted asset carries a content hash in production (name.hash.ext) but not
+// in dev, so strip the extension and an optional trailing 8-char hash.
+const imageName = (src: string): string => {
+	const base = (src.split('/').pop() ?? '').split('?')[0];
+	const noExt = base.replace(/\.[a-z0-9]+$/i, '');
+	return noExt.replace(/\.[\w-]{8}$/, '');
+};
+
 // Map the site's { img, caption } gallery schema onto Pandabox's fields.
 const images = (gallery?.data.images ?? []).map((image) => ({
 	src: image.img,
 	alt: image.caption,
 	title: image.caption,
 	description: '',
+	name: imageName(image.img.src),
 }));
 ---
 
@@ -38,6 +48,7 @@ const images = (gallery?.data.images ?? []).map((image) => ({
 					quality={40}
 					loading="eager"
 					data-index={index}
+					data-name={image.name}
 					class="thumbnail"
 				/>
 			</button>
@@ -47,7 +58,7 @@ const images = (gallery?.data.images ?? []).map((image) => ({
 		<div class="lightbox-content">
 			{
 				images.map((image, index) => (
-					<figure class="lightbox-image-container" id={`image-${index}`}>
+					<figure class="lightbox-image-container" id={image.name}>
 						<div class="lightbox-image-wrapper">
 							<Image
 								src={image.src}
@@ -363,8 +374,22 @@ const images = (gallery?.data.images ?? []).map((image) => ({
 		const closeDuration =
 			parseFloat(getComputedStyle(lightboxDialog).getPropertyValue('--duration-close-transition')) * 1000;
 
+		// Image containers in gallery order; each one's element id is the photo
+		// filename, so it serves as a static, reorder-proof anchor.
+		const containers = [...document.querySelectorAll<HTMLElement>('.lightbox-image-container')];
+
 		let currentIndex = 0;
 		let resizeTimeout: number | undefined;
+
+		// Shareable deep links: reflect the open image in the URL hash using its
+		// filename (the container's static id), so links survive gallery reordering.
+		const setHash = (index: number): void => {
+			const name = containers[index]?.id;
+			if (name) history.replaceState(null, '', `#${encodeURIComponent(name)}`);
+		};
+		const clearHash = (): void => {
+			history.replaceState(null, '', location.pathname + location.search);
+		};
 
 		function calculateCentering(image: HTMLImageElement): void {
 			const wrapper = image.closest('.lightbox-image-wrapper') as HTMLElement | null;
@@ -401,26 +426,26 @@ const images = (gallery?.data.images ?? []).map((image) => ({
 		}
 
 		function showImageAtIndex(index: number): void {
-			const containers = document.querySelectorAll<HTMLElement>('.lightbox-image-container');
 			if (index < 0 || index >= containers.length) return;
 
 			for (const container of containers) {
 				container.classList.remove('active', 'previous', 'next');
 			}
 
-			const newActive = document.getElementById(`image-${index}`);
+			const newActive = containers[index];
 			if (!newActive) return;
 
 			newActive.classList.add('active');
 			currentIndex = index;
+			setHash(currentIndex);
 
 			const image = newActive.querySelector<HTMLImageElement>('.lightbox-image');
 			if (image) calculateCentering(image);
 
 			const prevIndex = (currentIndex - 1 + containers.length) % containers.length;
 			const nextIndex = (currentIndex + 1) % containers.length;
-			document.getElementById(`image-${prevIndex}`)?.classList.add('previous');
-			document.getElementById(`image-${nextIndex}`)?.classList.add('next');
+			containers[prevIndex]?.classList.add('previous');
+			containers[nextIndex]?.classList.add('next');
 		}
 
 		function openLightbox(button: HTMLElement): void {
@@ -428,7 +453,7 @@ const images = (gallery?.data.images ?? []).map((image) => ({
 
 			const rect = button.getBoundingClientRect();
 			const index = Number.parseInt(button.dataset.index || '0', 10);
-			const activeImage = document.getElementById(`image-${index}`);
+			const activeImage = containers[index];
 			if (!activeImage) return;
 
 			activeImage.classList.add('active');
@@ -519,7 +544,15 @@ const images = (gallery?.data.images ?? []).map((image) => ({
 			for (const container of document.querySelectorAll<HTMLElement>('.lightbox-image-container')) {
 				container.classList.remove('active', 'previous', 'next');
 			}
+			clearHash();
 		});
+
+		// Open straight to a photo when the page is loaded with a #<filename> hash.
+		const target = decodeURIComponent(location.hash.slice(1));
+		if (target) {
+			const match = [...thumbnailButtons].find((t) => t.dataset.name === target);
+			if (match) openLightbox(match);
+		}
 	}
 
 	// This site does not use the View Transitions router, so init on DOM ready.

--- a/src/pages/photos/[...slug].astro
+++ b/src/pages/photos/[...slug].astro
@@ -5,6 +5,7 @@ import '../../styles/content.css';
 
 import Hero from '../../components/Hero.astro';
 import Icon from '../../components/Icon.astro';
+import Pandabox from '../../components/Pandabox.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { Image } from 'astro:assets';
 
@@ -46,14 +47,8 @@ const last_modified = entry.data.last_modified
 			<main class="wrapper">
 				<div class="stack gap-10 content">
 					{entry.data.img && <Image src={entry.data.img} alt={entry.data.img_alt || ''} />}
-					<div class="content">
-						{
-							entry.data.images.map((img) => (
-								<Image loading="lazy" src={img.img} alt={img.caption} quality={80} widths={[640]} />
-							))
-						}
-					</div>
 				</div>
+				<Pandabox gallery={entry} transitionType="fade" />
 			</main>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

Galleries are now a responsive thumbnail grid; clicking a photo opens a fullscreen lightbox. Built with the [**astro-pandabox**](https://github.com/SaintSin/astro-pandabox) component (SaintSin, MIT) — a **dependency-free, native `<dialog>`** lightbox — featuring:

- zoom-in-from-thumbnail animation, fade transition
- captions, keyboard + prev/next button navigation, touch swipe
- Escape / close-button to dismiss
- **shareable, reorder-proof deep links**

Adapted to this site rather than copied as-is:
- mapped to the existing YAML gallery schema (`{ img, caption }`) — **no content migration**
- changed the init trigger from `astro:page-load` to DOM-ready, since this site doesn't use the View Transitions router (otherwise the script never binds)

## Deep links (filename-based)

The open photo is reflected in the URL hash using its **source filename** (e.g. `…/photos/big#greece_milos.medium`), computed at build time and embedded as a `data-name` attribute so it is stable across dev/prod and **survives gallery reordering**. Opening/navigating updates the hash, closing clears it, loading a gallery URL with a matching `#<filename>` hash auto-opens that photo, and unknown names are ignored.

> Note: split from the original combined branch — the HAL 9000 404 page is now a separate PR (#388).

## Verification

- `astro check` / `eslint` / `prettier --check` / `astro build` all pass.
- **Exercised in real headless Chrome** (puppeteer), all assertions passed:
  - lightbox: multi-column thumbnail grid; click opens dialog with correct active image + numbered caption; ArrowRight / prev button navigate; close button and Escape dismiss.
  - deep links: opening sets `#<filename>`; ArrowRight advances to the next filename; closing clears the hash; visiting `…/photos/big#teneriffe_opera.medium` auto-opens that exact photo (by name, not position); unknown filename hash does not open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)