### PR TITLE
feat: orientation-aware image layout + lightbox in travel diaries

### DIFF
--- a/src/components/ContentImage.astro
+++ b/src/components/ContentImage.astro
@@ -1,0 +1,38 @@
+---
+// MDX `img` override for diary/article content. Lays images out by orientation
+// (landscape = half content width, portrait = a third, text floats around them)
+// and turns each into a trigger for <ContentLightbox />.
+import { getImage, Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+
+interface Props {
+	src: ImageMetadata | string;
+	alt?: string;
+}
+
+const { src, alt = '' } = Astro.props;
+
+// Travel images are local, so `src` is ImageMetadata. Remote/string images are
+// rendered plainly (no orientation sizing or lightbox).
+const meta = typeof src === 'string' ? null : src;
+const orientation = meta && meta.width >= meta.height ? 'landscape' : 'portrait';
+
+// Larger source for the fullscreen lightbox (served via the Netlify image CDN).
+const full = meta ? await getImage({ src: meta, width: 1600, quality: 80 }) : null;
+---
+
+{
+	meta ? (
+		<button
+			type="button"
+			class:list={['lightbox-trigger', 'content-image', orientation]}
+			data-full={full!.src}
+			data-caption={alt}
+			aria-label={alt ? `View image: ${alt}` : 'View image'}
+		>
+			<Image src={meta} alt={alt} width={640} quality={80} />
+		</button>
+	) : (
+		<img src={src as string} alt={alt} />
+	)
+}

--- a/src/components/ContentLightbox.astro
+++ b/src/components/ContentLightbox.astro
@@ -1,0 +1,164 @@
+---
+// Fullscreen lightbox for inline content images. It is DOM-driven: any element
+// with class `lightbox-trigger` on the page (see <ContentImage />) becomes a
+// trigger, carrying data-full (large image src) and data-caption.
+---
+
+<dialog class="content-lightbox" aria-label="Image viewer">
+	<button type="button" class="cl-btn cl-close" aria-label="Close">✕</button>
+	<button type="button" class="cl-btn cl-prev" aria-label="Previous image">‹</button>
+	<figure class="cl-figure">
+		<img class="cl-image" src="" alt="" />
+		<figcaption class="cl-caption"></figcaption>
+	</figure>
+	<button type="button" class="cl-btn cl-next" aria-label="Next image">›</button>
+</dialog>
+
+<style>
+	.content-lightbox {
+		width: 100vw;
+		max-width: 100vw;
+		height: 100dvh;
+		max-height: 100dvh;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		overflow: hidden;
+	}
+	.content-lightbox::backdrop {
+		background: oklch(20% 0 0 / 92%);
+	}
+	.cl-figure {
+		display: grid;
+		place-items: center;
+		gap: 1rem;
+		height: 100%;
+		margin: 0;
+		padding: 2rem;
+	}
+	.cl-image {
+		max-width: 92vw;
+		max-height: 82dvh;
+		object-fit: contain;
+		border-radius: 0.5rem;
+	}
+	.cl-caption {
+		max-width: 65ch;
+		color: oklch(95% 0 0);
+		text-align: center;
+		text-wrap: pretty;
+	}
+	.cl-caption:empty {
+		display: none;
+	}
+	.cl-btn {
+		position: fixed;
+		display: grid;
+		place-items: center;
+		width: 3rem;
+		height: 3rem;
+		border: 0;
+		border-radius: 50%;
+		background: oklch(0% 0 0 / 50%);
+		color: #fff;
+		font-size: 2rem;
+		line-height: 1;
+		cursor: pointer;
+	}
+	.cl-btn:hover,
+	.cl-btn:focus-visible {
+		background: oklch(0% 0 0 / 85%);
+	}
+	.cl-close {
+		top: 1rem;
+		right: 1rem;
+		cursor: zoom-out;
+	}
+	.cl-prev {
+		top: 50%;
+		left: 1rem;
+		transform: translateY(-50%);
+	}
+	.cl-next {
+		top: 50%;
+		right: 1rem;
+		transform: translateY(-50%);
+	}
+	@media (prefers-reduced-motion: no-preference) {
+		.cl-image {
+			animation: cl-zoom 0.25s ease;
+		}
+	}
+	@keyframes cl-zoom {
+		from {
+			opacity: 0;
+			transform: scale(0.97);
+		}
+		to {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+</style>
+
+<script>
+	function setupContentLightbox(): void {
+		const dialog = document.querySelector<HTMLDialogElement>('.content-lightbox');
+		const triggers = [...document.querySelectorAll<HTMLElement>('.lightbox-trigger')];
+		if (!dialog || triggers.length === 0) return;
+
+		const image = dialog.querySelector<HTMLImageElement>('.cl-image')!;
+		const caption = dialog.querySelector<HTMLElement>('.cl-caption')!;
+		const items = triggers.map((t) => ({ src: t.dataset.full ?? '', caption: t.dataset.caption ?? '' }));
+		let current = 0;
+
+		const show = (i: number): void => {
+			current = (i + items.length) % items.length;
+			image.src = items[current].src;
+			image.alt = items[current].caption;
+			caption.textContent = items[current].caption;
+		};
+		const open = (i: number): void => {
+			show(i);
+			if (!dialog.open) dialog.showModal();
+		};
+
+		triggers.forEach((trigger, i) => trigger.addEventListener('click', () => open(i)));
+		dialog.querySelector('.cl-next')!.addEventListener('click', () => show(current + 1));
+		dialog.querySelector('.cl-prev')!.addEventListener('click', () => show(current - 1));
+		dialog.querySelector('.cl-close')!.addEventListener('click', () => dialog.close());
+
+		dialog.addEventListener('keydown', (e) => {
+			if (e.key === 'ArrowRight') {
+				e.preventDefault();
+				show(current + 1);
+			} else if (e.key === 'ArrowLeft') {
+				e.preventDefault();
+				show(current - 1);
+			}
+		});
+
+		// Click on the backdrop (outside the figure) closes the viewer.
+		dialog.addEventListener('click', (e) => {
+			if (e.target === dialog) dialog.close();
+		});
+
+		// Touch swipe to navigate.
+		let touchStartX = 0;
+		dialog.addEventListener('touchstart', (e) => {
+			touchStartX = e.touches[0].clientX;
+		});
+		dialog.addEventListener('touchend', (e) => {
+			const deltaX = e.changedTouches[0].clientX - touchStartX;
+			if (deltaX > 50) show(current - 1);
+			else if (deltaX < -50) show(current + 1);
+		});
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', setupContentLightbox);
+	} else {
+		setupContentLightbox();
+	}
+</script>

--- a/src/pages/travels/[...slug].astro
+++ b/src/pages/travels/[...slug].astro
@@ -3,6 +3,8 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 
 import '../../styles/content.css';
 
+import ContentImage from '../../components/ContentImage.astro';
+import ContentLightbox from '../../components/ContentLightbox.astro';
 import Hero from '../../components/Hero.astro';
 import Icon from '../../components/Icon.astro';
 import Pill from '../../components/Pill.astro';
@@ -53,10 +55,11 @@ const last_modified = entry.data.last_modified
 				<div class="stack gap-10 content">
 					{entry.data.img && <Image src={entry.data.img} alt={entry.data.img_alt || ''} />}
 					<div class="content">
-						<Content />
+						<Content components={{ img: ContentImage }} />
 					</div>
 				</div>
 			</main>
 		</div>
 	</div>
+	<ContentLightbox />
 </BaseLayout>

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -90,3 +90,47 @@ header {
 	border-inline-start: 0.25rem solid var(--accent-dark);
 	color: var(--gray-0);
 }
+
+/* Inline diary images (see ContentImage.astro): float so text wraps around them,
+   landscape at half content-width, portrait at a third. Sides alternate. */
+.content-image {
+	display: block;
+	float: inline-end;
+	width: 50%;
+	margin: 0.5rem 0 1rem 1.5rem;
+	padding: 0;
+	border: 0;
+	background: none;
+	cursor: zoom-in;
+}
+
+.content-image.portrait {
+	width: 33%;
+}
+
+.content-image:nth-of-type(even) {
+	float: inline-start;
+	margin: 0.5rem 1.5rem 1rem 0;
+}
+
+.content-image img {
+	display: block;
+	width: 100%;
+	height: auto;
+}
+
+/* Begin each diary section below any preceding floated image. */
+.content h2,
+.content h3 {
+	clear: both;
+}
+
+/* On narrow screens the fractions are too small — go full width, no float. */
+@media (max-width: 50em) {
+	.content-image,
+	.content-image.portrait {
+		float: none;
+		width: 100%;
+		margin-inline: 0;
+	}
+}


### PR DESCRIPTION
## Summary

Improves how inline photos in travel diary entries (`src/content/travels/*/index.mdx`, plain `![](./img.jpg)` markdown) are presented — no content changes required.

### Orientation-aware layout
Inline diary images now **float so the text wraps around them**:
- **landscape** photos take **half** the content width
- **portrait** photos take **a third**
- sides **alternate** (right / left) for visual rhythm
- `## date` headings **clear** preceding floats so each diary day starts fresh
- below **50em** images go **full width** and stop floating

### Lightbox
Clicking any diary image opens it fullscreen, matching the gallery experience: prev/next (wraparound), arrow keys, touch swipe, and Escape / backdrop / close button. The lightbox image is served at 1600px via the Netlify image CDN.

## Implementation
- `src/components/ContentImage.astro` — MDX `img` override: detects orientation from `ImageMetadata` (width vs height), renders an optimized inline `<Image>`, and acts as a `.lightbox-trigger` carrying `data-full` (1600px src) + `data-caption` (alt text).
- `src/components/ContentLightbox.astro` — standalone, dependency-free DOM-driven `<dialog>` that wires up every `.lightbox-trigger` on the page.
- `src/pages/travels/[...slug].astro` — `<Content components={{ img: ContentImage }} />` + one `<ContentLightbox />`.
- `src/styles/content.css` — float/orientation/clear/mobile rules.

## Verification
- `astro check` / `eslint` / `prettier --check` / `astro build` all pass.
- **Exercised in real headless Chrome** on the Japan diary (14 images, 9 landscape / 5 portrait); all assertions passed: landscape ≈ 50% and portrait ≈ 33% of content width, images float with `zoom-in` cursor, headings clear floats, clicking opens the lightbox with the correct 1600px image + caption, ArrowRight navigates, Escape closes, and at 390px width images are full-width and unfloated. Screenshots confirmed the wrapped-text layout and the fullscreen lightbox.

## Notes
- This adds a **second** lightbox (gallery pages use astro-pandabox on PR #387). They share the look but not code; once #387 merges, a small follow-up can unify them. Filename-based deep-linking (a gallery feature) is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)