### PR TITLE
fix: redirect /sitemap.xml to /sitemap-index.xml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,8 @@
   from = "/projects/2018-software/"
   to = "/projects"
   status = 301
+
+[[redirects]]
+  from = "/sitemap.xml"
+  to = "/sitemap-index.xml"
+  status = 301


### PR DESCRIPTION
## Was

Fügt einen 301-Redirect von `/sitemap.xml` auf `/sitemap-index.xml` in der `netlify.toml` hinzu.

## Warum

`https://veeck.de/sitemap.xml` lieferte bisher die 404-Seite. Die echte Sitemap (Astro-Sitemap-Integration) liegt unter `/sitemap-index.xml` und ist zwar in der robots.txt korrekt referenziert, aber Google und andere Crawler probieren gerne den Standardpfad `/sitemap.xml`. Mit dem Redirect landen sie jetzt an der richtigen Stelle.

Gefunden bei der Analyse des GSC-Abdeckungsberichts vom 2026-07-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)