### PR TITLE
feat: per-section accent colors

### DIFF
--- a/src/components/CategoryHero.astro
+++ b/src/components/CategoryHero.astro
@@ -43,7 +43,11 @@ const { title, tagline, image, imageAlt, align = 'center', imagePosition = 'cent
 	}
 
 	.category-hero-figure {
+		position: relative;
 		margin: 0;
+		/* keep the duotone blend scoped to the photo: without isolation the
+		   overlapping scrim can make the browser blend against the page instead */
+		isolation: isolate;
 	}
 
 	.category-hero-figure :global(img) {
@@ -71,8 +75,13 @@ const { title, tagline, image, imageAlt, align = 'center', imagePosition = 'cent
 		display: grid;
 		place-items: center;
 		padding: 1.5rem;
-		/* scrim so title and tagline stay readable on the photo */
-		background: radial-gradient(ellipse at center, rgba(9, 6, 16, 0.6) 0%, rgba(9, 6, 16, 0.25) 75%);
+		/* accent-tinted scrim so title and tagline stay readable on the photo
+		   without washing the duotone out to gray */
+		background: radial-gradient(
+			ellipse at center,
+			color-mix(in srgb, var(--accent-scrim) 60%, transparent) 0%,
+			color-mix(in srgb, var(--accent-scrim) 25%, transparent) 75%
+		);
 	}
 
 	.category-hero-content :global(.title) {
@@ -88,7 +97,12 @@ const { title, tagline, image, imageAlt, align = 'center', imagePosition = 'cent
 	/* start-aligned variant: text sits on the left, scrim darkens from the left */
 	.category-hero-content.start {
 		justify-items: start;
-		background: linear-gradient(90deg, rgba(9, 6, 16, 0.65) 0%, rgba(9, 6, 16, 0.35) 45%, rgba(9, 6, 16, 0.05) 75%);
+		background: linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--accent-scrim) 65%, transparent) 0%,
+			color-mix(in srgb, var(--accent-scrim) 35%, transparent) 45%,
+			color-mix(in srgb, var(--accent-scrim) 5%, transparent) 75%
+		);
 	}
 
 	@media (min-width: 50em) {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,12 +17,21 @@ interface Props {
 	last_modified?: string | undefined;
 	og_type?: 'website' | 'article' | undefined;
 	published_time?: string | undefined;
+	accent?: 'purple' | 'teal' | 'amber' | 'green' | 'blue' | undefined;
 }
 
-const { title, description, lang = 'en', last_modified = '', og_type = 'website', published_time } = Astro.props;
+const {
+	title,
+	description,
+	lang = 'en',
+	last_modified = '',
+	og_type = 'website',
+	published_time,
+	accent = 'purple',
+} = Astro.props;
 ---
 
-<html lang={lang}>
+<html lang={lang} data-accent={accent}>
 	<head>
 		<MainHead title={title} description={description} lang={lang} ogType={og_type} publishedTime={published_time} />
 		<Font cssVariable="--font-body" preload />
@@ -100,6 +109,7 @@ const { title, description, lang = 'en', last_modified = '', og_type = 'website'
 			}
 
 			.backgrounds {
+				position: relative;
 				min-height: 100%;
 				isolation: isolate;
 				background:
@@ -116,12 +126,28 @@ const { title, description, lang = 'en', last_modified = '', og_type = 'website'
 					/*header2*/ normal,
 					/*base*/ normal;
 			}
+			/* Re-hue the purple background art for non-default accents. The hue
+			   layer sits above the background images (negative z-index child) but
+			   below all content, so only the backdrop shifts color. */
+			:root:not([data-accent='purple']) .backgrounds::before {
+				content: '';
+				position: absolute;
+				inset: 0;
+				z-index: -1;
+				background: linear-gradient(150deg, var(--accent-hue-a), var(--accent-hue-b));
+				mix-blend-mode: hue;
+				pointer-events: none;
+			}
+
 			@media (forced-colors: active) {
 				/* Deactivate custom backgrounds for high contrast users. */
 				.backgrounds {
 					background: none;
 					background-blend-mode: none;
 					--bg-gradient-size: none;
+				}
+				.backgrounds::before {
+					content: none;
 				}
 			}
 		</style>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -13,7 +13,7 @@ const posts = (await getCollection('blog')).sort(
 );
 ---
 
-<BaseLayout title="My blog | Veeck" description="Learn about ramblings and stuff I find noteworthy">
+<BaseLayout accent="teal" title="My blog | Veeck" description="Learn about ramblings and stuff I find noteworthy">
 	<div class="stack gap-20">
 		<main class="wrapper stack gap-8">
 			<CategoryHero

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -33,6 +33,7 @@ const first_published = entry.data.first_published
 ---
 
 <BaseLayout
+	accent="teal"
 	title={entry.data.title}
 	description={entry.data.description}
 	lang={entry.data.lang}

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -13,7 +13,7 @@ const galleries = (await getCollection('galleries')).sort(
 );
 ---
 
-<BaseLayout title="My galleries | Veeck" description="Learn about Veeck's most recent galleries">
+<BaseLayout accent="amber" title="My galleries | Veeck" description="Learn about Veeck's most recent galleries">
 	<div class="stack gap-20">
 		<main class="wrapper stack gap-8">
 			<CategoryHero

--- a/src/pages/photos/[...slug].astro
+++ b/src/pages/photos/[...slug].astro
@@ -32,7 +32,7 @@ const last_modified = entry.data.last_modified
 	: '';
 ---
 
-<BaseLayout title={entry.data.title} description={entry.data.lead} last_modified={last_modified}>
+<BaseLayout accent="amber" title={entry.data.title} description={entry.data.lead} last_modified={last_modified}>
 	<div class="stack gap-20">
 		<div class="stack gap-15">
 			<header>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -13,7 +13,7 @@ const projects = (await getCollection('projects')).sort(
 );
 ---
 
-<BaseLayout title="My Projects | Veeck" description="Learn about Veeck's most recent projects">
+<BaseLayout accent="green" title="My Projects | Veeck" description="Learn about Veeck's most recent projects">
 	<div class="stack gap-20">
 		<main class="wrapper stack gap-8">
 			<CategoryHero

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -34,7 +34,13 @@ const last_modified = entry.data.last_modified
 	: '';
 ---
 
-<BaseLayout title={entry.data.title} description={entry.data.lead} lang={entry.data.lang} last_modified={last_modified}>
+<BaseLayout
+	accent="green"
+	title={entry.data.title}
+	description={entry.data.lead}
+	lang={entry.data.lang}
+	last_modified={last_modified}
+>
 	<div class="stack gap-20">
 		<div class="stack gap-15">
 			<header>

--- a/src/pages/travels.astro
+++ b/src/pages/travels.astro
@@ -13,7 +13,7 @@ const travels = (await getCollection('travels')).sort(
 );
 ---
 
-<BaseLayout title="My travels | Veeck" description="Learn about Veeck's most recent travels">
+<BaseLayout accent="blue" title="My travels | Veeck" description="Learn about Veeck's most recent travels">
 	<div class="stack gap-20">
 		<main class="wrapper stack gap-8">
 			<CategoryHero

--- a/src/pages/travels/[...slug].astro
+++ b/src/pages/travels/[...slug].astro
@@ -36,6 +36,7 @@ const last_modified = entry.data.last_modified
 ---
 
 <BaseLayout
+	accent="blue"
 	title={entry.data.title}
 	description={entry.data.lead}
 	lang={entry.data.lang}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -105,6 +105,82 @@
 		0px 16px 16px rgba(255, 255, 255, 0.1), 0px 4px 9px rgba(255, 255, 255, 0.12);
 }
 
+/* Per-section accent palettes, selected via data-accent on <html>.
+   The default (purple) palette above stays untouched; --accent-hue-a/b
+   drive the hue-shift layer that recolors the background images. */
+:root {
+	--accent-hue-a: #c561f6;
+	--accent-hue-b: #7611a6;
+}
+
+:root[data-accent='teal'] {
+	--accent-light: #2dd4bf;
+	--accent-regular: #0f766e;
+	--accent-dark: #022c26;
+	--accent-overlay: hsla(172, 66%, 50%, 0.33);
+	--accent-hue-a: #14b8a6;
+	--accent-hue-b: #0ea5e9;
+}
+:root.theme-dark[data-accent='teal'] {
+	--accent-light: #022c26;
+	--accent-regular: #0f766e;
+	--accent-dark: #2dd4bf;
+	--accent-overlay: hsla(172, 66%, 50%, 0.33);
+	--accent-subtle-overlay: hsla(172, 60%, 25%, 0.33);
+	--gradient-stop-1: #0d9488;
+}
+
+:root[data-accent='amber'] {
+	--accent-light: #fbbf24;
+	--accent-regular: #b45309;
+	--accent-dark: #451a03;
+	--accent-overlay: hsla(43, 96%, 56%, 0.33);
+	--accent-hue-a: #f59e0b;
+	--accent-hue-b: #ef4444;
+}
+:root.theme-dark[data-accent='amber'] {
+	--accent-light: #451a03;
+	--accent-regular: #b45309;
+	--accent-dark: #fbbf24;
+	--accent-overlay: hsla(43, 96%, 56%, 0.33);
+	--accent-subtle-overlay: hsla(31, 92%, 30%, 0.33);
+	--gradient-stop-1: #d97706;
+}
+
+:root[data-accent='green'] {
+	--accent-light: #4ade80;
+	--accent-regular: #15803d;
+	--accent-dark: #052e16;
+	--accent-overlay: hsla(142, 69%, 58%, 0.33);
+	--accent-hue-a: #22c55e;
+	--accent-hue-b: #84cc16;
+}
+:root.theme-dark[data-accent='green'] {
+	--accent-light: #052e16;
+	--accent-regular: #15803d;
+	--accent-dark: #4ade80;
+	--accent-overlay: hsla(142, 69%, 58%, 0.33);
+	--accent-subtle-overlay: hsla(143, 64%, 24%, 0.33);
+	--gradient-stop-1: #16a34a;
+}
+
+:root[data-accent='blue'] {
+	--accent-light: #38bdf8;
+	--accent-regular: #0369a1;
+	--accent-dark: #082f49;
+	--accent-overlay: hsla(199, 93%, 60%, 0.33);
+	--accent-hue-a: #0ea5e9;
+	--accent-hue-b: #6366f1;
+}
+:root.theme-dark[data-accent='blue'] {
+	--accent-light: #082f49;
+	--accent-regular: #0369a1;
+	--accent-dark: #38bdf8;
+	--accent-overlay: hsla(199, 93%, 60%, 0.33);
+	--accent-subtle-overlay: hsla(201, 96%, 32%, 0.33);
+	--gradient-stop-1: #0284c7;
+}
+
 html,
 body {
 	min-height: 100%;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,6 +111,8 @@
 :root {
 	--accent-hue-a: #c561f6;
 	--accent-hue-b: #7611a6;
+	/* always-dark accent tone for image scrims; not flipped by .theme-dark */
+	--accent-scrim: #1c0056;
 }
 
 :root[data-accent='teal'] {
@@ -120,6 +122,7 @@
 	--accent-overlay: hsla(172, 66%, 50%, 0.33);
 	--accent-hue-a: #14b8a6;
 	--accent-hue-b: #0ea5e9;
+	--accent-scrim: #022c26;
 }
 :root.theme-dark[data-accent='teal'] {
 	--accent-light: #022c26;
@@ -137,6 +140,7 @@
 	--accent-overlay: hsla(43, 96%, 56%, 0.33);
 	--accent-hue-a: #f59e0b;
 	--accent-hue-b: #ef4444;
+	--accent-scrim: #451a03;
 }
 :root.theme-dark[data-accent='amber'] {
 	--accent-light: #451a03;
@@ -154,6 +158,7 @@
 	--accent-overlay: hsla(142, 69%, 58%, 0.33);
 	--accent-hue-a: #22c55e;
 	--accent-hue-b: #84cc16;
+	--accent-scrim: #052e16;
 }
 :root.theme-dark[data-accent='green'] {
 	--accent-light: #052e16;
@@ -171,6 +176,7 @@
 	--accent-overlay: hsla(199, 93%, 60%, 0.33);
 	--accent-hue-a: #0ea5e9;
 	--accent-hue-b: #6366f1;
+	--accent-scrim: #082f49;
 }
 :root.theme-dark[data-accent='blue'] {
 	--accent-light: #082f49;


### PR DESCRIPTION
## Was

Schluss mit Lila überall — jeder Bereich bekommt seine eigene Akzentfarbe:

| Bereich | Akzent |
|---|---|
| /blog | Teal |
| /photos | Amber |
| /projects | Grün |
| /travels | Blau |
| Home, Resume, 404 | Lila (unverändert) |

Gilt jeweils für Übersichts- **und** Detailseiten, in Light- und Dark-Mode.

## Wie

- `BaseLayout` bekommt ein `accent`-Prop und stempelt `data-accent` auf `<html>`.
- Die Paletten in `global.css` überschreiben pro Akzent die Custom Properties (`--accent-*`, `--gradient-stop-1`, Overlays) für beide Themes — Pills, Links, Gradients, CTA-Buttons und der aktive Nav-Punkt folgen automatisch, ohne dass Komponenten angefasst werden mussten.
- Die lila Hintergrund-JPEGs werden **nicht ersetzt**: Eine `mix-blend-mode: hue`-Ebene (Pseudo-Element mit negativem z-index, oberhalb der Hintergrundbilder, unterhalb des Contents) färbt die vorhandene Grafik zur Laufzeit um. Bei `forced-colors` deaktiviert, beim Standard-Lila gar nicht erst gerendert.
- Neue Farbe hinzufügen = ein CSS-Block + ein Prop-Wert.

## Verifikation

- Alle vier Bereiche + Startseite im Browser geprüft (Light + Dark)
- `build`, `check` (0 errors), `lint` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)