### PR TITLE
feat: resurrect 2005/2006 Blogger posts as archive blog entries

### DIFF
--- a/src/content/blog/2005-blogger-archive.mdx
+++ b/src/content/blog/2005-blogger-archive.mdx
@@ -1,0 +1,225 @@
+---
+title: 'Aus dem Archiv: Blog 2005'
+description: 19 gerettete Einträge aus meinem alten Blogger-Blog von 2005
+lang: de
+first_published: 2005-05-01
+tags:
+  - archive
+---
+
+Gerettet aus einem Blogger-Export von 2013: die ersten Einträge meines damaligen Blogs, geschrieben in Freiburg. Manche
+Links führen inzwischen ins Leere — sie bleiben trotzdem stehen, wie es sich für ein Archiv gehört.
+
+## 1. Mai 2005
+
+Welcome to my little web-page now with 100% more blog! On this page I will post all the news about this site and my life
+but sadly for the english speaking folks only in german.
+
+So if you're in the unfortunate situation of not speaking 'kraut', please feel free to roam around the site looking at
+the pictures. If you get caught by your partner, then you can always say that you were tricked into it by me!
+
+## 2. Mai 2005
+
+Freunde, fragt ihr euch, warum ich auch mit diesem modernen Zeug anfange, meine Gedanken rauszuschleudern in die Welt,
+die dann doch nichts anderes ist als ein leeres Fass, das höchstens einmal mit Öl gefuellt und in Brand gesteckt wird,
+um ein paar alte Maenner an einer noch älteren Strassenecke vor dem Erfrieren zu bewahren.
+
+Also der Grund fuer mein 'Blogging' ist, dass mein Doktor mir gesagt hat, dass ich meine Gedanken niederschreiben soll.
+Um genauer zu sein, habe ich mir gesagt, dass ich einen Doktor haben sollte, der mir sowas sagt. Also habe ich den
+Mittelsmann ausgelassen (den Doktor) und versuche hiermit, meine Schreibkünste zu verbessern in der Hoffnung, irgendwann
+damit mal was zu erreichen und sei es nur, um euch zum Lächeln zu bringen!
+
+Ach ja, und so kann der geneigte Freund, sollte es ihn/sie denn geben, sich einen kleinen Überblick darüber verschaffen,
+wenn sich neue Panoramabilder und Texte auf diese Seite verirrt haben. Seid also gespannt!
+
+## 4. Mai 2005
+
+Um dem vielfachen Wunsch nach einem mir ebenbürtigen Bild in der Freundesgalerie nachzukommen, habe ich ein eben solches
+auf die Seite gestellt. Ich präsentier hiermit: [Der Guru](http://www.veeck.de/pic_friends.html#f4)! Einfach auf mein
+kleines, altes Bild klicken, um das aktuellste von mir zu sehen.
+
+## 9. Mai 2005
+
+Dieses Wochenende habe ich endlich die Zeit gefunden, meine Reiseberichte aus Amerika auf die Seite zu stellen, auch
+wenn einige White-Russian-Coktails, die ich am Samstag-Abend traf, mich daran durch selbstinduziertes Kopfweh am Sonntag
+hindern wollten. Die Berichte sind auf der bekannten [Adresse](http://www.veeck.de/travel_05_usa.html) zu finden.
+
+Die besten Bilder habe ich gleich mit dazu gepackt und auch die [Panorama Seite](http://www.veeck.de/pic_panorama.html)
+wurde aktualisiert mit neuen Bilder aus Amerika und neuen von Bastian Müller, Teynas Mitbewohner.
+
+Oh, und wenn euch was auf dem Herzen brennt und ihr mir nicht gleich eine Email schicken wollt, so kann man zu jeder
+Nachricht auch einen Kommentar hinzufügen: einfach auf die Schrift unterhalb der Einträge klicken.
+
+## 28. Mai 2005
+
+Wenn ich denn mal sterbe, bin ich dann koscher?
+
+Denn ich besitze einen Organspendeausweis (den ihr auch alle haben solltet), welcher in meinem Totesfall durch meine
+noch intakten Organe jemand anderem zum Weiterleben verhilft. Wenn ich nun nicht koscher wäre, dürfte ein Jude dann noch
+als Transplantationsempfänger dienen? Ich hoffe, die Notärzte bedenken so etwas bei den Rettungsversuchen. Eine Gruppe
+habe ich aber auf jeden Fall explizit von der Liste der Empfänger gestrichen: Nazis. Meine Organe haben auch ihren
+Stolz.
+
+War gestern auf meiner ersten Pyjama-Party. Memo an mich selber: Einen eigenen Seidenpyjama kaufen, weiss mit blauen
+Blümchen!
+
+## 4. Juni 2005
+
+Wahrscheinlich zum ersten Mal in meinem Leben ein AmericanFootball-Spiel von den Zuschauerrängen gesehen. Während des
+Spiels merkte ich dann ausserdem:
+
+- mir war nicht bewusst, wie langsam es von der Seite aussieht (oder alle Spieler sind Ampullariidae geworden)
+- ich bin wohl zu alt für den Scheiss
+- Football würde mit seinem Buddhismushintergrund (Alles ist Friede) nicht mehr zu mir passen
+- der Coach ist immer noch der alte Sack, der mir einmal zu oft ans Bein gepinkelt hat Zum Spiel: Auch ohne eine
+  nennenswerte Offenseline zu haben, haben die [Freiburg Sacristans](http://www.sacristans.de/home.php) das Ding mit
+  21:6 gegen Lauda nach Hause geschaukelt.
+
+## 6. Juni 2005
+
+Hier ist ein Deal: Damit ich mal endlich weiss, ob dies einer liest, schreibe ich in die Kommentarseite eine Sache, vor
+der ich Angst habe. Für jeden weiteren Kommentar von jemand anderem, der eine seiner Ängste beschreibt, schreibe ich
+eine weitere Sache hinzu.
+
+> **Kommentar (veeck, 6. Juni 2005):** Ok, eine Sache, vor der ich Angst habe:
+>
+> - diesem einen Traum, den ich mir nie merken kann, der mir aber dennoch kalte Schauer verursacht, wenn ich nur an ihn
+>   denke
+
+## 5. August 2005
+
+IIIIIk, ich werde alt! So viel schnell geht naemlich die Zeit vorbei, wenn man alt wird, und nun habe ich schon zwei
+Monate nicht mit mir selber geredet. Diese Selbstgespräche fuehre ich nämlich, da anscheinend sonst keiner das liest.
+Egal, viel ist trotzdem passiert:
+
+- Ich war zum ersten Mal im [Drifters-Club](http://www.drifters-club.de/) in Freiburg, und ich bin nicht vermessen, wenn
+  ich sage, dass es auch das letzte Mal war. Die Ehre gebührt dafür Heiko Schraut, der mich volltrunken, wie wir waren,
+  mit seinen weltschmerzverzerrtem Gesicht dazu überredete.
+- Ich war (auch zum ersten Mal) auf dem [Linux-Tag](http://www.linuxtag.org/) in Karlsruhe, und ich kann nun sagen, dass
+  Gott neben Mann und Frau wirklich ein Drittes Geschlecht, den Computer-Geek, geschaffen hat. Noch bin ich mir
+  unsicher, wie sie sich vermehren, aber ich tippe auf asexuelle und orgiastische Selbstteilung, wozu der Linuxtag und
+  anderes wahrscheinlich das Balzritual mit sich selber ist. Zu blöd, dass ich selber manchmal dazu gehöre
+  [...](http://debian.stro.at/kjt/2.6.9-kjt1/split/min-max-arch_sh_cchips_hd6446x_hd64465_io.patch)
+- Dazu hab ich den ersten Sproessling unserer Marburger Studenten Clique kennengelernt. Paul "Der Kolben" Peitz
+  (geborener Schmidt, aber wer will als FDP-Wähler schon wie ein alter SPD-Kanzler heissen) hat es geschafft und
+  zusammen mit seiner Frau einen kleinen Wonneproppen bekommen, der wohl später Brüste und soviel Männer wie sie will
+  kriegn wird. Wer wird wohl der nächste sein?
+
+- Ich war (wiederum zum ersten Mal) im Freien klettern. Es hat Spass gemacht, auch wenn die von mir in Strassenschuhe
+  erreichte Höhe von unten betrachtet, richtig mickrig war. Egal, ich hab meine kleine Freundin glücklich gemacht, und
+  es hat nicht mal wehgetan.
+- Ich habe neben der perfekten Wurst, (die Berner Grillwurst, die eine mit Käse gefüllte und mit Speck ummantelte
+  kulinarische Sauerei ist) den perfekten Grillnachtisch gefunden: Banane mit darin zerschmolzener Cocos-Schokolade. Das
+  Verlangen danach brennt nun dauernd in meinem Mund.
+- Negative Neuigkeiten: Der beste Koreaner der Stadt hat seine Pforten geschlossen.
+
+Das solls mal für jetzt sein, das ex-Tops, ex-Cartoon macht heute unter dem Namen "Eimer" wieder auf, ganz in der
+Tradition blöder Namen bleibend. Und wer wird dort wohl sein? Euer lieblicher Veeck.
+
+## 18. August 2005
+
+Douglas Adams Für Einsteiger: Anstatt gleich mit der Tür ins Haus bzw. auf die Schnauze zu fallen (und somit das
+Douglas'sche Theorem nachzuweisen, dass man sehr einfach fliegen kann, indem man einfach hinfällt, und den Boden
+verfehlt), gibt es für den geneigten Leser einfachere Arten, das zugrundeliegende Prinzip näher kennen zu lernen: Man
+gehe auf die Toilette und sei dabei so vertieft und erschreckt über die noch zu erledigenden Sachen des Tages bzw. der
+Nacht (was z.B. noch um halb 1 Uhr nachts noch Wäsche aufzuhängen haben umfasst), dass man nach dem Austreten und dem
+Aufhaengen der Wäsche auf die Leine ersteres schon wieder vergessen und immer noch ein Druckgefühl in der Blase hat. Die
+Verwirrung hält aber bei näherer Betrachtung der Abläufe nur kurz an und dem normalen Tages bzw. Nachtablauf kann in
+Ruhe weiter nachgegangen werden. Was allemal besser ist, als wie es Douglas Probanden ergeht, die meist aus recht
+grosser Höhe abstürzen, wenn sie sich der Unmöglichkeit ihrer Flugkünste bewusst werden und die Schwerkraft wieder ihr
+hässliches Haupt erhebt.
+
+## 21. August 2005
+
+Merkt euch Kinder: 4 White Russians sind für einen normal gebauten Mann das Limit, auch wenn man vorher gut gegessen
+hat. Mehr und das Geld für das Essen ist rausgeschmissen!
+
+## 13. September 2005
+
+Frauen dieser Welt, schaut auf diesen Link:
+
+[Glenn Feron](http://www.glennferon.com/portfolio1/index.html)
+
+Dieser Mann ist ein professioneller Bilderretuschierer, der die Fotos der sogenannten Schönen und Berühmten
+nachbearbeitet, damit sie auf den Hochglanzmagazinen so wie in euren Alpträumen aussehen, die ihr nur habt, weil die
+Alicia Keys und Hale Berrys dieser Welt ja soooo makellos sind. Viel Spass beim Betrachten der Vorher-Nachher-Bilder.
+
+## 17. September 2005
+
+Und noch ein Link aus dem grossen Netz, welches die Leute fischt:
+[Create your own visited countries map](http://douweosinga.com/projects/visitedcountries)
+
+Meine besuchte Weltkugel umfasst somit:
+
+_(Hier war eine „Visited Countries“-Weltkarte von world66.com eingebettet — den Dienst gibt es nicht mehr.)_
+
+Ich zählte dabei nur die Länder, in denen ich mich wirklich längere Zeit aufgehalten habe, also gelten meine
+Durchfahrten durch Slowenien oder Alkohol einkaufen in der ersten Tankstelle hinter der französisch-spanischen Grenze
+nicht! Trotzdem habe ich schon beachtliche 17 Länder und damit 7% der Weltkugel gesehen. Nur noch 93%! Südamerika,
+Afrika ich komme (und bringe Teyna mit)!
+
+## 21. September 2005
+
+[So knapp vor Platz 1](http://www.google.com/search?q=veeck)
+
+## 2. Oktober 2005
+
+Drei entspannte Tage in Leipzig liegen hinter mir, wo ich meine Freundin Birgit besucht habe. Sehens- und
+berichtenswertes war (neben Birgit natürlich):
+
+- Ein altes Kino, was nun als Konzerthaus mit gediegenen Sitzen und reichlich viel Patina eine tolle Atmosphäre für
+  [Tias Carlson](http://www.tiascarlson.com/) bot.
+- Der [Leipziger Zoo](http://www.zoo-leipzig.de/index.php), der zeigt wie ein Zoo sowohl den Tieren als auch den
+  Besuchern das beste bieten kann: Weite Flächen, die man als Besucher gut einsehen kann und die Tier genug Platz zum
+  Austoben bieten, ohne dass es sich gleich in die eigene Kacke setzen muss. Und für die Damen: Es gab viele kleine
+  süüüüsse Tierbabys, unter anderem Erdhörnchen, und sogar Hyänenbabies sehen knuddelig aus, solange sie noch klein und
+  tapsig sind.
+- 15:18 Uhr fährt der Zug aus Leipzig nach Frankurt ab, nicht um 15:38!
+- Nebenbei hab ich festgestellt, dass meine
+  [Liste von bereits besuchten Ländern](http://douweosinga.com/projects/visitedcountries) unvollständig war, denn die
+  überaus wichtigen Kleinstaaten Vatikan und Luxemburg habe ich vergessen. Somit sind es also 19 Staaten (8%) und immer
+  noch liegen Afrika und Südamerika voraus:
+
+_(Hier war eine „Visited Countries“-Weltkarte von world66.com eingebettet — den Dienst gibt es nicht mehr.)_
+
+## 18. Oktober 2005
+
+Und wieder ein Beispiel dafür, wie sinnfrei Terrorismusbekämpfung sein kann,
+[nachzulesen im Guardian.](http://http://www.guardian.co.uk/comment/story/0,,1575411,00.html)
+
+Und wer hats angefangen?
+[Dieser Meister der Rethorik](http://politicalhumor.about.com/od/bushquotes/a/topbushisms2004.htm) wars.
+
+## 23. Oktober 2005
+
+When automatic translation goes wrong:
+
+**Beweisstück A**: Der schon etwas krude englische [Originale Text](http://centralasiatravel.com/)
+
+**Beweisstück B**: Der anscheinend von einem schizophrenen übersetzte
+[Text](http://centralasiatravel.com/deutsch/default.html), nur ist jeder absatz zweimal übersetzt.
+
+## 1. November 2005
+
+Für alle die, die der WindowsMediaPlayer zu bunt und unübersichtlich ist und ein einfaches und gutes Abspielprogramm für
+Filme suchen, habe ich die neueste Version des MediaPlayerClassic von Gabest
+[zum Download ](http://veeck.de/material/Media%20Player%20Classic%20v6.4.8.5.exe)bereit gestellt.
+
+Alles was ihr dann noch braucht, um Filme anzuschauen, ist
+[ffdshow](http://fileforum.betanews.com/detail/FFDShow_MPEG4_Video_Decoder/1054056131/1), sowie
+[Real Alternative](http://www.free-codecs.com/download/Real_Alternative.htm) für RealTime Filme und
+[Quicktime Alternative](http://www.free-codecs.com/download/QuickTime_Alternative.htm) für Quicktime Filme.
+
+Nebenbei: Alle Programme sind Freeware.
+
+## 15. November 2005
+
+Google irrt nie und hier ist der Beweis:
+
+Gebt mal in [Google](http://www.google.de/) den Suchbegriff " failure " (zu deutsch: Versager) ein und klickt dann auf
+den Button " Auf gut Glück "....
+
+## 24. November 2005
+
+Auch Geeks (in diesem Fall ein Linux-Kernel-Entwickler) haben einen Sinn für
+[politische Satire](http://vger.kernel.org/~davem/cgi-bin/blog.cgi/2005/11/23#war_on_ants).

--- a/src/content/blog/2006-blogger-archive.mdx
+++ b/src/content/blog/2006-blogger-archive.mdx
@@ -1,0 +1,95 @@
+---
+title: 'Aus dem Archiv: Blog 2006'
+description: 7 gerettete Einträge aus meinem alten Blogger-Blog von 2006
+lang: de
+first_published: 2006-02-13
+tags:
+  - archive
+---
+
+Der zweite und letzte Jahrgang meines alten Blogger-Blogs, ebenfalls aus dem Export von 2013 gerettet.
+
+## 13. Februar 2006
+
+Endlich, nach einem Monat [WorldOfWarcraft](http://www.wow-europe.com/de/)-Sucht konnte ich mich nun dazu aufraffen,
+meinen Panama-Urlaub aufzuarbeiten. Neben meinem Reisetagebuch, welches sich nun (noch ohne Bilder) auf diesen Webseiten
+[wiederfindet](http://www.veeck.de/travel_05_panama.html), habe ich natürlich zuvor meine Weltkarte mit besuchten
+Ländern aktualisiert. Gott, 20 Länder hört sich nach all den Reisen immer noch so wenig an und es sind immer noch 92%
+der Welt unerforscht für mich, sieht aber nach so viel aus: _(Hier war eine „Visited Countries“-Weltkarte von
+world66.com eingebettet — den Dienst gibt es nicht mehr.)_
+
+## 14. Februar 2006
+
+Ein Quiz: **Kaffemaschine oder Waffentyp**?
+
+- AK-47
+- M-90 Automatic
+- KF550-BK
+- XM15-E2S Schamlos geklaut aus einem Blog eines Microsoft-Mitarbeiters. Jetzt wissen wir also zumindest zwei Dinge die
+  dort waehrend der Arbeitszeit wirklich passieren: Kaffetrinken und Waffenkaufen. Die Auflösung stelle ich später in
+  die Kommentare des Eintrags.
+
+> **Kommentar (veeck, 24. März 2006):** Coffee Machine (CM) oder Assault Weapon (AW) ? AK-47: AW M-90 Automatic: CM
+> KF550-BK: CM XM15-E2S: AW
+
+## 23. März 2006
+
+_Take my love, take my land_ _Take me where I cannot stand_ _I don't care, I'm still free_ _You can't take the sky from
+me_ _Take me out to the black_ _Tell them I ain't comin' back_ _Burn the land and boil the sea_ _You can't take the sky
+from me_ _There's no place I can be_ _Since I found Serenity_ _But you can't take the sky from me..._
+
+> **Kommentar (veeck, 24. März 2006):** Für die, die keine Geeks sind, sei gesagt, dass dies die Titelmelodie der Serie
+> Firefly ist, ein leider zu schnell abgesetzte Science-Fiction-Western-Serie in den USA. Sehr empfehlenswert, wenn man
+> die Enterprise-Serien zu sauber findet und/oder nicht mehr auf Jean-Luc Picard steht.
+
+## 6. April 2006
+
+Fast haette ich es vergessen: **ALLE **meine Bilder aus Panama und meinem Ski-Urlaub im Maerz sind auch online zu finden
+und zwar unter diesen Links:
+
+[Panama](http://veeck.dyndns.org/Alben/Panama/index.html) mit Teyna, viel gruene Waelder, blaues Meer, alles zum
+neidisch werden
+
+[Nendaz](http://veeck.dyndns.org/Alben/Nendaz06/index.html) mit den Jungs, nur wenig Interessantes fuer Aussenstehende,
+ausser den Filmen von Skispringen
+
+Seid aber gewarnt: Da diese Bilder auf nem richtigen kleinen alten PC in unserem Hausflur liegen und somit nur ueber DSL
+an die weite Welt angebunden sind, kann es durchaus sein, dass man nur selten auf diese Seiten kommt. Einfach spaeter
+dann nochmal probieren.
+
+## 26. April 2006
+
+[**T-1**:](http://veeck.de/pic_friends.html#f1) (was mehr Sinn für euch ergeben wird, je weiter die Zeit fortschreitet)
+
+du bist in england, und ich sitz am elbstrand mit augenrändern denk dann, verdammt du kannst nichts daran ändern lass
+dich nich hängen man nun liegt zwischen uns der elbekanal bei heimweh bleibt die zeit stehen, und worte werden banal
+lächerlich, an manchen tagen fühlte es sich an wie ein messerstich an dem meine laune dem hamburger wetter glich doch
+ich besser mich, und denk an dich auf meiner durststrecke während ich mich durch meine texte vor dem konkurs rette ich
+bereu es täglich das ich nicht in deiner nähe bin statt mit dir am frühstückstisch, sitz ich allein vorm catering ich
+sag dir jedes wochenende lebe wohl, und denk mir scheisse wie gerne würde ich in deiner nähe wohnen gedanklich bist du
+bei mir, lässt die uni schleifen ich dreh innerlich durch, wie bei der formel 1 die gummireifen flüchte mich in meine
+traumwelt und dann geht es schon doch frage mich wie lang du es aushälst mit mir am telefon
+
+## 27. April 2006
+
+[T-0](http://veeck.de/pic_friends.html#f1)\*\* \*\*und alles was ich sagen kann:
+
+You said I began This messy state of love affair And I drink too much and smoke too fast And this city's cleared my
+innocence
+
+Coffee is pouring out my ears It's the only thing they have in here And my heart stops beating
+
+And when it stops it stops My heart stopped beating And when it stops it stops My heart stopped beating
+
+## 3. Mai 2006
+
+[**T+6**](http://www.veeck.de/pic_friends.html#f1) und seit Samstag nichts ist mehr wie es einmal war.
+
+> **Kommentar (Anonymous, 8. Mai 2006):** hey veeck!
+>
+> vielen dank für deinen besuch am wochenende, ich hoffe, wir konnten dir ein paar schöne stunden geben. würde mich
+> freuen, dich und die anderen bald wieder hier begrüssen zu dürfen.
+>
+> szti
+>
+> p.s.: ich warte auf die bilder :)


### PR DESCRIPTION
## Was

Holt die 26 Blog-Einträge (Mai 2005 – Mai 2006) aus dem alten Blogger-Export (`todo/blog-08-17-2013.xml`) zurück ins Blog — als zwei Jahres-Archivposts:

- **„Aus dem Archiv: Blog 2005"** — 19 Einträge, 1 Kommentar
- **„Aus dem Archiv: Blog 2006"** — 7 Einträge, 3 Kommentare

## Wie

- Jeder Eintrag ist ein datierter Abschnitt (`## 1. Mai 2005`), Kommentare hängen als Blockquotes mit Autor und Datum am jeweiligen Eintrag.
- Blogger-HTML wurde nach Markdown konvertiert (`<br>`, Links, Listen, Fettung); MDX-Spezialzeichen sind escaped.
- Die drei eingebetteten world66-„Visited Countries"-Karten sind tot (Dienst existiert nicht mehr) und durch eine kursive Notiz ersetzt. Alle anderen Links — auch die inzwischen toten — bleiben stehen, wie es sich für ein Archiv gehört.
- `first_published` = Datum des jeweils ersten Eintrags, dadurch sortieren sich beide Posts ganz ans Ende der Blog-Übersicht und verdrängen nichts Neues.
- Getaggt mit `archive`, `lang: de`.

Hinweis: Basiert auf main **vor** dem Merge von #408 (Altlasten-Löschung) — die Quelldatei wird dort mitgelöscht, was nach diesem PR auch völlig in Ordnung ist: Der Inhalt lebt dann im Blog weiter.

## Verifikation

- Build, check, lint, format grün
- Beide Seiten im Browser geprüft (Rendering, Kommentar-Blockquotes, Sortierung in der Übersicht)

🤖 Generated with [Claude Code](https://claude.com/claude-code)