### PR TITLE
feat: hero banner with overlaid text on detail pages

### DIFF
--- a/src/components/CategoryHero.astro
+++ b/src/components/CategoryHero.astro
@@ -17,7 +17,9 @@ interface Props {
 const { title, tagline, image, imageAlt, align = 'center', imagePosition = 'center' } = Astro.props;
 ---
 
-<header class="category-hero">
+<!-- div, not header: pages wrap this in their own <header>, and the
+     page-level header styles (content.css) must not leak into the banner -->
+<div class="category-hero">
 	<figure class="category-hero-figure">
 		<Image
 			src={image}
@@ -25,6 +27,8 @@ const { title, tagline, image, imageAlt, align = 'center', imagePosition = 'cent
 			widths={[480, 800, 1440]}
 			sizes="100vw"
 			style={`object-position: ${imagePosition}`}
+			loading="eager"
+			fetchpriority="high"
 		/>
 	</figure>
 	<div class:list={['category-hero-content', align]}>
@@ -32,7 +36,7 @@ const { title, tagline, image, imageAlt, align = 'center', imagePosition = 'cent
 			<slot />
 		</Hero>
 	</div>
-</header>
+</div>
 
 <style>
 	.category-hero {

--- a/src/components/CategoryHero.astro
+++ b/src/components/CategoryHero.astro
@@ -98,6 +98,25 @@ const { title, tagline, image, imageAlt, align = 'center', imagePosition = 'cent
 		text-shadow: 0 1px 8px rgba(9, 6, 16, 0.6);
 	}
 
+	/* pills lose their filled background on the banner and render as plain text */
+	.category-hero-content :global(.pill) {
+		padding: 0;
+		border: none;
+		background: none;
+		color: #eae6f5;
+		text-shadow: 0 1px 8px rgba(9, 6, 16, 0.6);
+	}
+
+	.category-hero-content :global(.pill + .pill)::before {
+		content: '·';
+		margin-right: 0.5rem;
+	}
+
+	.category-hero-content.center :global(.tags),
+	.category-hero-content.center :global(.roles) {
+		justify-content: center;
+	}
+
 	/* start-aligned variant: text sits on the left, scrim darkens from the left */
 	.category-hero-content.start {
 		justify-items: start;

--- a/src/pages/photos/[...slug].astro
+++ b/src/pages/photos/[...slug].astro
@@ -4,11 +4,10 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 import '../../styles/content.css';
 
 import GalleryGrid from '../../components/GalleryGrid.astro';
-import Hero from '../../components/Hero.astro';
+import CategoryHero from '../../components/CategoryHero.astro';
 import Icon from '../../components/Icon.astro';
 import Lightbox from '../../components/Lightbox.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { Image } from 'astro:assets';
 
 interface Props {
 	entry: CollectionEntry<'galleries'>;
@@ -38,17 +37,16 @@ const last_modified = entry.data.last_modified
 			<header>
 				<div class="wrapper stack gap-2">
 					<a class="back-link" href="/photos/"><Icon icon="arrow-left" /> Galleries</a>
-					<Hero title={entry.data.title} align="start">
-						<div class="details">
-							<p>{entry.data.lead}</p>
-						</div>
-					</Hero>
+					<CategoryHero
+						title={entry.data.title}
+						tagline={entry.data.lead}
+						image={entry.data.img}
+						imageAlt={entry.data.img_alt || ''}
+					/>
 				</div>
 			</header>
 			<main class="wrapper stack gap-15">
-				<div class="stack gap-10 content">
-					{entry.data.img && <Image src={entry.data.img} alt={entry.data.img_alt || ''} />}
-				</div>
+				<div class="stack gap-10 content"></div>
 				<GalleryGrid gallery={entry} />
 			</main>
 		</div>

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -4,11 +4,10 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 import '../../styles/content.css';
 import '../../components/mdx/SpecsTabs.css';
 
-import Hero from '../../components/Hero.astro';
+import CategoryHero from '../../components/CategoryHero.astro';
 import Icon from '../../components/Icon.astro';
 import Pill from '../../components/Pill.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { Image } from 'astro:assets';
 import { render } from 'astro:content';
 
 interface Props {
@@ -46,19 +45,20 @@ const last_modified = entry.data.last_modified
 			<header>
 				<div class="wrapper stack gap-2">
 					<a class="back-link" href="/projects/"><Icon icon="arrow-left" /> Projects</a>
-					<Hero title={entry.data.title} align="start">
-						<div class="details">
-							<p>{entry.data.lead}</p>
-							<div class="tags">
-								{entry.data.tags.map((t) => <Pill>{t}</Pill>)}
-							</div>
+					<CategoryHero
+						title={entry.data.title}
+						tagline={entry.data.lead}
+						image={entry.data.img}
+						imageAlt={entry.data.img_alt || ''}
+					>
+						<div class="tags">
+							{entry.data.tags.map((t) => <Pill>{t}</Pill>)}
 						</div>
-					</Hero>
+					</CategoryHero>
 				</div>
 			</header>
 			<main class="wrapper">
 				<div class="stack gap-10 content">
-					{entry.data.img && <Image src={entry.data.img} alt={entry.data.img_alt || ''} />}
 					<div class="content">
 						<Content />
 					</div>

--- a/src/pages/travels/[...slug].astro
+++ b/src/pages/travels/[...slug].astro
@@ -4,13 +4,12 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 import '../../styles/content.css';
 
 import ContentImage from '../../components/ContentImage.astro';
-import Hero from '../../components/Hero.astro';
+import CategoryHero from '../../components/CategoryHero.astro';
 import Icon from '../../components/Icon.astro';
 import Lightbox from '../../components/Lightbox.astro';
 import Pill from '../../components/Pill.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { render } from 'astro:content';
-import { Image } from 'astro:assets';
 
 interface Props {
 	entry: CollectionEntry<'travels'>;
@@ -49,19 +48,20 @@ const last_modified = entry.data.last_modified
 			<header>
 				<div class="wrapper stack gap-2">
 					<a class="back-link" href="/travels/"><Icon icon="arrow-left" /> Travels</a>
-					<Hero title={entry.data.title} align="start">
-						<div class="details">
-							<p>{entry.data.lead}</p>
-							<div class="tags">
-								{entry.data.tags.map((t) => <Pill>{t}</Pill>)}
-							</div>
+					<CategoryHero
+						title={entry.data.title}
+						tagline={entry.data.lead}
+						image={entry.data.img}
+						imageAlt={entry.data.img_alt || ''}
+					>
+						<div class="tags">
+							{entry.data.tags.map((t) => <Pill>{t}</Pill>)}
 						</div>
-					</Hero>
+					</CategoryHero>
 				</div>
 			</header>
 			<main class="wrapper">
 				<div class="stack gap-10 content">
-					{entry.data.img && <Image src={entry.data.img} alt={entry.data.img_alt || ''} />}
 					<div class="content">
 						<Content components={{ img: ContentImage }} />
 					</div>


### PR DESCRIPTION
## Was

Die Detailseiten von **Travels, Projects und Galleries** nutzen jetzt dieselbe `CategoryHero`-Banner-Optik wie die Übersichtsseiten: Das Titelbild des Eintrags wird zum vollbreiten Banner mit Titel, Lead und Tag-Pills zentriert darauf — statt Text-Hero plus separatem Bild am Content-Anfang. Duotone-Färbung folgt automatisch dem Bereichs-Akzent (blau/grün/amber).

**Blog-Detailseiten bleiben unverändert** — Blog-Posts haben im Schema kein Titelbild.

## Nebenbei gefixt

- **`CategoryHero` rendert jetzt ein `div` statt `header`**: Die Detailseiten wrappen den Banner in ihr eigenes `<header>`; die Seiten-Header-Regel aus `content.css` (padding-bottom + border) sickerte als grauer Streifen ins Banner (und header-in-header ist ohnehin invalides HTML).
- **`loading="eager"` + `fetchpriority="high"`** fürs Banner-Bild: Es ist immer above-the-fold; das bisherige Lazy Loading verursachte sichtbares Nachploppen und ist fürs LCP kontraproduktiv. Gilt automatisch auch für die Übersichtsseiten.

## Verifikation

- Travels- (Japan), Projects- (Magic Mirror) und Galleries-Detailseite (around the world) im Browser geprüft, ebenso die Übersichtsseiten nach dem div-Umbau
- `build`, `check` (0 errors), `lint` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)