### PR TITLE
fix: keep the newest entry topmost in the offset grid

### DIFF
--- a/src/components/Grid.astro
+++ b/src/components/Grid.astro
@@ -40,15 +40,10 @@ const { variant } = Astro.props;
 			padding-bottom: var(--row-offset);
 		}
 
-		/* Shift first item in each row vertically to create staggered effect. */
-		.grid.offset > :global(:nth-child(odd)) {
+		/* Shift second item in each row vertically to create the staggered
+		   effect while the newest entry stays top-left. */
+		.grid.offset > :global(:nth-child(even)) {
 			transform: translateY(var(--row-offset));
-		}
-
-		/* If last row contains only one item, display it in the second column. */
-		.grid.offset > :global(:last-child:nth-child(odd)) {
-			grid-column: 2 / 3;
-			transform: none;
 		}
 
 		.grid.small {

--- a/src/components/previews/BlogPreview.astro
+++ b/src/components/previews/BlogPreview.astro
@@ -38,7 +38,8 @@ const { data, id } = Astro.props.post;
 		z-index: 1;
 		margin: 0.5rem;
 		padding: 0.5rem 1rem;
-		background: var(--gray-999);
+		/* surface tinted with the page's section accent */
+		background: color-mix(in srgb, var(--accent-regular) 12%, var(--gray-999));
 		color: var(--gray-200);
 		border-radius: 0.375rem;
 	}

--- a/src/components/previews/GalleryPreview.astro
+++ b/src/components/previews/GalleryPreview.astro
@@ -40,7 +40,8 @@ const { data, id } = Astro.props.gallery;
 		z-index: 1;
 		margin: 0.5rem;
 		padding: 0.5rem 1rem;
-		background: var(--gray-999);
+		/* surface tinted with the page's section accent */
+		background: color-mix(in srgb, var(--accent-regular) 12%, var(--gray-999));
 		color: var(--gray-200);
 		border-radius: 0.375rem;
 	}

--- a/src/components/previews/PortfolioPreview.astro
+++ b/src/components/previews/PortfolioPreview.astro
@@ -40,7 +40,8 @@ const { data, id } = Astro.props.project;
 		z-index: 1;
 		margin: 0.5rem;
 		padding: 0.5rem 1rem;
-		background: var(--gray-999);
+		/* surface tinted with the page's section accent */
+		background: color-mix(in srgb, var(--accent-regular) 12%, var(--gray-999));
 		color: var(--gray-200);
 		border-radius: 0.375rem;
 	}

--- a/src/components/previews/TravelPreview.astro
+++ b/src/components/previews/TravelPreview.astro
@@ -40,7 +40,8 @@ const { data, id } = Astro.props.travel;
 		z-index: 1;
 		margin: 0.5rem;
 		padding: 0.5rem 1rem;
-		background: var(--gray-999);
+		/* surface tinted with the page's section accent */
+		background: color-mix(in srgb, var(--accent-regular) 12%, var(--gray-999));
 		color: var(--gray-200);
 		border-radius: 0.375rem;
 	}


### PR DESCRIPTION
## Was

Auf den Übersichtsseiten (Travels, Blog, Projects, Galleries) schob der Offset-Grid die **ungeraden** Karten nach unten — also auch die neueste, wodurch die zweitneueste Karte optisch zuoberst stand. Jetzt werden stattdessen die **geraden** Karten (rechte Spalte) versetzt: Der neueste Eintrag steht oben links und ist zugleich der höchste.

Die Sonderregel, die einen einzelnen letzten Eintrag in die rechte Spalte verschob, ist damit obsolet (ungerade Items werden nicht mehr transformiert) und wurde entfernt.

## Außerdem (cce3e645)

Die Titel-Chips auf den Vorschau-Karten waren flaches `--gray-999`; sie mischen jetzt 12 % der Bereichs-Akzentfarbe in die Fläche (`color-mix`) und nehmen so den Farbton der jeweiligen Seite an — Travels blau, Blog teal, usw., in Light- und Dark-Mode.

## Verifikation

- Travels (gerade Anzahl) und Blog (9 Einträge, ungerade — letzter Eintrag steht sauber links) im Browser geprüft, Positionen per DOM-Messung bestätigt
- `build`, `check`, `lint` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)
